### PR TITLE
Use the name AX Visio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # OpenAPI Developer Example Application
 
-This is a minimal Android Application to show the usage of the OpenAPI provided
-by the *SO Comm SDK*. That the application uses only a very small feature of
-the OpenAPI is intentional. The app showcases instead the necessary steps,
+This is a minimal Android Application to show the usage of the OpenAPI to
+connect to the AX Visio. The application uses only a very small feature of the
+OpenAPI. This is intentional. The app should only showcase the necessary steps,
 UI screens and code to guide the user
 
-* to grant the necessary Android Permissions to the app and enable Bluetooth,
-* to connect to the Falke using the SDK
-* to start the OpenAPI app with the selection wheel
+* to grant the necessary Android permissions to the app and enable Bluetooth,
+* to connect to the AX Visio using the *SOCommOutsideAPI* library and
+* to start the OpenAPI Inside Application with the selection wheel
 
-Only after these setup steps are completed, the OpenAPI and other contexts can
-be used.
+Only after these setup steps are completed, the OpenAPI contexts and other
+contexts can be used.
 
-To see all features of the OpenAPI and other contexts, please see the API
-reference.
+To see all features of the OpenAPI, please see the
+[Swarovski Optik OpenAPI Documentation](https://swarovskioptik.github.io/openapi-docu/).
 
 The difference screens and user steps are
 
@@ -23,11 +23,11 @@ The difference screens and user steps are
 # How to use the example code
 
 The code should demonstrate the necessary steps, UI interfaces and user flow to
-connect to the Falke and use the OpenAPI. It's intended to be a reference
+connect to the AX Visio and to use the OpenAPI. It's intended to be a reference
 implementation to look at the code and to copy the relevant parts into your own
 application. All the error cases and possibilities are handled. Examples: the
 users selects a different app on the selection wheel or the user power down
-the Falke. In these cases the app switches back to the relevant screen.
+the AX Visio. In these cases the app switches back to the relevant screen.
 
 The code is _not_ a showcase of general Android Application development best
 practices. For example the app just uses a single activity and the different screens
@@ -38,19 +38,19 @@ or similar libraries.
 Furthermore the UI of the example is very basic. For example there are no
 transitions between the different screens. This is sometimes confusing because
 the transitions happen not based on user input, but on external events, like
-losing the connection to the Falke. A real world application is expected to
+losing the connection to the AX Visio. A real world application is expected to
 provide a better user experience.
 
 For a good user experience some in-process animations are needed. For example
 when the app search for available Fakle devices in reach or when the device
-connects to a Falke device. Otherwise the user does not know that a operation
+connects to a AX Visio device. Otherwise the user does not know that a operation
 is in progress.
 
 
 # How to build it
 
 Before building the app, you need the OpenAPI API key. It's a JSON web token
-that grants your application to specific contexts on the Falke Device.
+that grants your application to specific contexts on the AX Visio device.
 
 After receiving the key from Swarovski, add it to the `local.properties` files
 as the constant `OPENAPI_API_KEY`. Example:

--- a/app/src/main/java/com/example/openapideveloperexampleapp/MainActivity.kt
+++ b/app/src/main/java/com/example/openapideveloperexampleapp/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : Activity() {
     enum class UIState {
         NONE, // Only used initially for the first transition
         REQUEST_PERMISSIONS_AND_BLUETOOTH,
-        CONNECT_TO_FALKE,
+        CONNECT_TO_AX_VISIO,
         WAIT_FOR_OPENAPI_INSIDE_APP,
         MAIN,
     }
@@ -154,14 +154,14 @@ class MainActivity : Activity() {
         }
     }
 
-    private fun showConnectToFalkeScreen() {
-        setContentView(R.layout.connect_to_falke)
+    private fun showConnectToAXVisioScreen() {
+        setContentView(R.layout.connect_to_ax_visio)
 
-        val buttonConnectToFolke = findViewById<Button>(R.id.buttonConnectToFalke)
+        val buttonConnectToFolke = findViewById<Button>(R.id.buttonConnectToAXVisio)
 
         // Disable the button until at least one device is found
         buttonConnectToFolke.isEnabled = false
-        buttonConnectToFolke.text = getString(R.string.connect_to_falke, "UNKNOWN")
+        buttonConnectToFolke.text = getString(R.string.connect_to_ax_visio, "UNKNOWN")
 
         // TODO: This code starts the search and stops when the first device is found.
         // A real world application would continue the search and show the user a list of
@@ -187,13 +187,13 @@ class MainActivity : Activity() {
                 atomicDeviceValue.set(foundDevice.deviceName)
                 buttonConnectToFolke.isEnabled = true
                 buttonConnectToFolke.text =
-                    getString(R.string.connect_to_falke, foundDevice.deviceName)
+                    getString(R.string.connect_to_ax_visio, foundDevice.deviceName)
 
                 // Dispose the Observable now. This will stop the search process.
                 deviceSearchDisposables.dispose()
             }, { e ->
-                Log.e(TAG, "Error while searching Falke devices", e)
-                Toast.makeText(this, "Error while searching for Falke devices!", Toast.LENGTH_SHORT)
+                Log.e(TAG, "Error while searching AX Visio devices", e)
+                Toast.makeText(this, "Error while searching for AX Visio devices!", Toast.LENGTH_SHORT)
                     .show()
             }
             )
@@ -203,7 +203,7 @@ class MainActivity : Activity() {
             button.isEnabled = false
 
             sdk!!.connect(atomicDeviceValue.get())
-                // Add a timeout. Otherwise the screen will block forever when no Falke device
+                // Add a timeout. Otherwise the screen will block forever when no AX Visio device
                 // is in reach! But the timeout must also be long enough so the user can handle
                 // the initial pairing.
                 .timeout(60, TimeUnit.SECONDS)
@@ -214,8 +214,8 @@ class MainActivity : Activity() {
                         updateStateAndMaybeUI()
                     }, { e ->
                         button.isEnabled = true
-                        Log.e(TAG, "Connect connect to the Falke device", e)
-                        Toast.makeText(this, "Connecting to Falke failed!", Toast.LENGTH_SHORT)
+                        Log.e(TAG, "Connect connect to the AX Visio device", e)
+                        Toast.makeText(this, "Connecting to AX Visio failed!", Toast.LENGTH_SHORT)
                             .show()
                         updateStateAndMaybeUI()
                     }
@@ -231,16 +231,16 @@ class MainActivity : Activity() {
             .subscribe({ state ->
                 if (DEBUG) Log.d(TAG, "connectionState: $state")
                 if (state == SOCommOutsideAPI.ConnectionState.Disconnected) {
-                    Log.w(TAG, "Connection to falke lost!")
+                    Log.w(TAG, "Connection to AX Visio lost!")
                     Toast.makeText(
                         this,
-                        "Connection to Falke lost. Please try to reconnect",
+                        "Connection to AX Visio lost. Please try to reconnect",
                         Toast.LENGTH_SHORT
                     ).show()
                 }
             }, { e ->
                 Log.e(TAG, "Connection state failed!", e)
-                Toast.makeText(this, "Connection to Falke failed!", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, "Connection to AX Visio failed!", Toast.LENGTH_SHORT).show()
                 updateStateAndMaybeUI()
             })
             .addTo(disposables)
@@ -266,7 +266,7 @@ class MainActivity : Activity() {
                         .addTo(disposables)
                 } else {
                     // OpenAPIContextBLE context was removed. Maybe the user has turned off
-                    // the screen or selected another app with the selection key on the Falke.
+                    // the screen or selected another app with the selection wheel on the AX Visio.
                     updateStateAndMaybeUI()
                 }
             }
@@ -277,8 +277,8 @@ class MainActivity : Activity() {
         setContentView(R.layout.main)
 
         // NOTE: You should check for errors on the Completable object. But these will only include
-        // errors on the local side, e.g. a lost connection to the Falke.
-        // The remote side, the falke, does not report errors, e.g. a wrong keyCode name or
+        // errors on the local side, e.g. a lost connection to the AX Visio.
+        // The remote side, the AX Visio, does not report errors, e.g. a wrong keyCode name or
         // a wrong procedure value.
         val params = ConfigureKeyActionProcedure.Params(
             "SCROLL_KEY",
@@ -291,7 +291,7 @@ class MainActivity : Activity() {
                 Log.e(TAG, "Configure the key ActionProcedure failed!", e)
                 Toast.makeText(
                     this,
-                    "Failed to configure the key on the Falke.",
+                    "Failed to configure the key on the AX Visio.",
                     Toast.LENGTH_SHORT
                 ).show()
             })
@@ -306,7 +306,7 @@ class MainActivity : Activity() {
         if (connectionState == SOCommOutsideAPI.ConnectionState.Connecting
             || connectionState == SOCommOutsideAPI.ConnectionState.Disconnected
         )
-            return UIState.CONNECT_TO_FALKE
+            return UIState.CONNECT_TO_AX_VISIO
 
         if (!sdk!!.availableContexts.blockingFirst().contains(SOContext.OpenAPIContextBLE)
             || !sdk!!.contextsInUse.blockingFirst().contains(SOContext.OpenAPIContextBLE)
@@ -323,7 +323,7 @@ class MainActivity : Activity() {
             if (DEBUG) Log.d(TAG, "Switch UI from $uiState to $newUIState")
             when (newUIState) {
                 UIState.REQUEST_PERMISSIONS_AND_BLUETOOTH -> showRequestPermissionsAndBluetoothScreen()
-                UIState.CONNECT_TO_FALKE -> showConnectToFalkeScreen()
+                UIState.CONNECT_TO_AX_VISIO -> showConnectToAXVisioScreen()
                 UIState.WAIT_FOR_OPENAPI_INSIDE_APP -> showWaitForOpenAPIInsideAppScreen()
                 UIState.MAIN -> showMainScreen()
                 UIState.NONE -> throw RuntimeException("Should never happen")

--- a/app/src/main/res/layout/connect_to_ax_visio.xml
+++ b/app/src/main/res/layout/connect_to_ax_visio.xml
@@ -15,33 +15,33 @@
         android:layout_marginEnd="16dp"
         android:text="Screen 2"
         android:textSize="34sp"
-        app:layout_constraintBottom_toTopOf="@+id/textViewConnectToFalke"
+        app:layout_constraintBottom_toTopOf="@+id/textViewConnectToAXVisio"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/textViewConnectToFalke"
+        android:id="@+id/textViewConnectToAXVisio"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:gravity="center"
-        android:text="Searching for a Falke device in reach. When a device is found, you can touch the button to connect to it."
+        android:text="Searching for an AX Visio device in reach. When a device is found, you can touch the button to connect to it."
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:id="@+id/buttonConnectToFalke"
+        android:id="@+id/buttonConnectToAXVisio"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="Connect To Falke"
+        android:text="Connect To AX VIsio"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textViewConnectToFalke"
+        app:layout_constraintTop_toBottomOf="@+id/textViewConnectToAXVisio"
         app:layout_constraintVertical_bias="0.0" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -29,7 +29,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:gravity="center"
-        android:text="The SCROLL_KEY (with an arrow on it) on the Falke is now configured to take a picture. Try it out!"
+        android:text="The SCROLL_KEY (with an arrow on it) on the AX Visio is now configured to take a picture. Try it out!"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/wait_for_openapi_inside_app.xml
+++ b/app/src/main/res/layout/wait_for_openapi_inside_app.xml
@@ -29,7 +29,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:gravity="center"
-        android:text="The OpenAPI Inside App is not started on the Falke. Use the Selection Wheel to start the OpenAPI App. If the Screen is off, press the power button to turn on the screen. You should see the text 'Please Connect'."
+        android:text="The OpenAPI Inside App is not started on the AX Visio. Use the Selection Wheel to start the OpenAPI App. If the Screen is off, press the power button to turn on the screen. You should see the text 'Please Connect'."
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">OpenAPIDeveloperExampleApp</string>
-    <string name="connect_to_falke">Connect to Falke (%1$s)</string>
+    <string name="connect_to_ax_visio">Connect to AX Visio (%1$s)</string>
 </resources>


### PR DESCRIPTION
Replace the internal code name of the binocular with the official product name: 'AX Visio'