### PR TITLE
Fix OPENAPI_API_KEY handling in local.properties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         } else {
             val p = Properties()
             p.load(project.rootProject.file("local.properties").reader())
-            if (!p.contains("OPENAPI_API_KEY")) throw Exception("Please add 'OPENAPI_API_KEY' property!")
+            if (!p.containsKey("OPENAPI_API_KEY")) throw Exception("Please add 'OPENAPI_API_KEY' property!")
             p.getProperty("OPENAPI_API_KEY")
         }
         debug {


### PR DESCRIPTION
This patch fixes the commit cad1aca9 ("Allow OPENAPI_API_KEY property in user wide file"). Without this patch a developer could now use the local.properties file to add the OPENAPI_API_KEY. The error and fix is quite obvious.