### PR TITLE
Remove permissions from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,13 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/openapideveloperexampleapp/ConnectActivity.kt
+++ b/app/src/main/java/com/example/openapideveloperexampleapp/ConnectActivity.kt
@@ -185,7 +185,6 @@ class ConnectActivity : Activity() {
                 mutableListOf(
                     Manifest.permission.BLUETOOTH_SCAN,
                     Manifest.permission.BLUETOOTH_CONNECT,
-                    Manifest.permission.BLUETOOTH_ADVERTISE
                 )
             )
         }


### PR DESCRIPTION
Remove the permissions from the manifest. The permissions are already declared in the dependency SOCommOutsideAPI. So the are automatically merged into the final App manifest.

On the way remove the permission `BLUETOOTH_ADVERTISE`. It's not needed and mostly a copy&paste mistake.

Tested on Android 11 (Pixel2) and Android 13 (FP3).