### PR TITLE
Update Maven repo reference to external-friendly URL

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = uri("https://artifacts.swarovskioptik.com/repository/maven-swarovski-optik/"))
+        maven(url = uri("https://artifacts.swarovskioptik.com/repository/external-maven-swarovski-optik/"))
     }
 }
 


### PR DESCRIPTION
The current Maven repo URL (https://artifacts.swarovskioptik.com/repository/maven-swarovski-optik/) is for internal users and Swarovski employees only and requires login credentials.

The new URL is for external developers and requires no credentials. 

The external-friendly URL was handed over by Swarovski representatives.